### PR TITLE
Issue #30 and #29, and a suggestion for ease of use.

### DIFF
--- a/library/include/borealis/button.hpp
+++ b/library/include/borealis/button.hpp
@@ -58,7 +58,7 @@ class Button : public View
     float cornerRadiusOverride = 0;
 
   public:
-    Button(ButtonStyle style);
+    Button(ButtonStyle style = ButtonStyle::PLAIN);
     ~Button();
 
     void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, Style* style, FrameContext* ctx) override;

--- a/library/lib/sidebar.cpp
+++ b/library/lib/sidebar.cpp
@@ -42,8 +42,8 @@ View* Sidebar::getDefaultFocus()
         this->lastFocus = 0;
 
     View* toFocus{ nullptr };
+    // Try to focus last focused one
     if(this->children.size() != 0)
-        // Try to focus last focused one
         toFocus = this->children[this->lastFocus]->view->getDefaultFocus();
     
     if (toFocus)

--- a/library/lib/sidebar.cpp
+++ b/library/lib/sidebar.cpp
@@ -41,8 +41,11 @@ View* Sidebar::getDefaultFocus()
     if (this->lastFocus >= this->children.size())
         this->lastFocus = 0;
 
-    // Try to focus last focused one
-    View* toFocus = this->children[this->lastFocus]->view->getDefaultFocus();
+    View* toFocus{ nullptr };
+    if(this->children.size() != 0)
+        // Try to focus last focused one
+        toFocus = this->children[this->lastFocus]->view->getDefaultFocus();
+    
     if (toFocus)
         return toFocus;
 

--- a/library/lib/tab_frame.cpp
+++ b/library/lib/tab_frame.cpp
@@ -64,11 +64,9 @@ void TabFrame::switchToView(View* view)
         this->layout->removeView(1, false);
     }
 
-    if (view != nullptr)
-    {
-        this->layout->addView(view, true, true); // addView() calls willAppear()
-        this->rightPane = view;
-    }
+    this->rightPane = view;
+    if (this->rightPane != nullptr)
+        this->layout->addView(this->rightPane, true, true); // addView() calls willAppear()
 }
 
 void TabFrame::addTab(std::string label, View* view)


### PR DESCRIPTION
I found two bugs (and fixed them of course), one where a program could segfault when a SideBar has no child and where a Tabframe will not switch to any view after it has encountered one view that is a nullptr.
I also modified the constructor of brls::Button to default construct a PLAIN button for ease of use.