### PR TITLE
Fix macro expansion problems under MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ APP_VERSION	:=	1.0
 
 ROMFS				:=	resources
 BOREALIS_PATH		:=	.
-BOREALIS_RESOURCES	:=	romfs:/
+BOREALIS_RESOURCES	:=	romfs:\/
 
 #---------------------------------------------------------------------------------
 # options for code generation


### PR DESCRIPTION
Under MSYS2 on Windows the building using the provided Makefile causes a macro expansion problem (probably due to Windows path slash weirdness). Simply escaping the forward slash seems to fix this