### PR TITLE
Set BOREALIS_RESOURCES to default to romfs:/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ APP_VERSION	:=	1.0
 
 ROMFS				:=	resources
 BOREALIS_PATH		:=	.
-BOREALIS_RESOURCES	:=	romfs:/
 
 #---------------------------------------------------------------------------------
 # options for code generation
@@ -59,8 +58,7 @@ ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
 CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
-CFLAGS	+=	$(INCLUDE) -D__SWITCH__ \
-			-DBOREALIS_RESOURCES="\"$(BOREALIS_RESOURCES)\""
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
 CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=c++1z -O2
 

--- a/library/include/borealis.hpp
+++ b/library/include/borealis.hpp
@@ -20,7 +20,7 @@
 #pragma once
 
 #ifndef BOREALIS_RESOURCES
-#error BOREALIS_RESOURCES define missing
+#define BOREALIS_RESOURCES "romfs:/"
 #endif
 #define BOREALIS_ASSET(_str) BOREALIS_RESOURCES _str
 


### PR DESCRIPTION
This fixes compilation under Windows paths without breaking unix paths