### PR TITLE
Skip MSYS2 path conversion in the example makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@MSYS2_ARG_CONV_EXCL="-D;$(MSYS2_ARG_CONV_EXCL)" make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
https://www.msys2.org/wiki/Porting/

This PR is supposed to mitigate the following error people might encounter when building the borealis example for the Switch.

`error: missing terminating " character`

This is due to the fact programs under MSYS2 will try to convert path in arguments and env variables matching the pattern `XXX:/` and convert them to a posix path. We skip this behavior for defines by telling MSYS2 to skip arguments starting with `-D`