### PR TITLE
TabFrame and Dialog modifications.

### DIFF
--- a/library/include/borealis/tab_frame.hpp
+++ b/library/include/borealis/tab_frame.hpp
@@ -27,6 +27,24 @@
 namespace brls
 {
 
+class ViewContainer : public View {
+public:
+  void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, Style* style, FrameContext* ctx) override;
+  void layout(NVGcontext* vg, Style* style, FontStash* stash) override;
+  View* getDefaultFocus() override;
+
+  /**
+   * Set the view for the view container. 
+   * Calling this will call willDisappear for the previous view, and
+   * setParent and willAppear for the new view.
+   */
+  void setView(View* view);
+  bool hasView()
+  { return associated_view != nullptr; }
+private:
+  View* associated_view{ nullptr };
+};
+
 // An applet frame containing a sidebar on the left with multiple tabs
 class TabFrame : public AppletFrame
 {
@@ -51,9 +69,7 @@ class TabFrame : public AppletFrame
   private:
     Sidebar* sidebar;
     BoxLayout* layout;
-    View* rightPane = nullptr;
-
-    void switchToView(View* view);
+    ViewContainer* rightPane;
 };
 
 } // namespace brls

--- a/library/lib/dialog.cpp
+++ b/library/lib/dialog.cpp
@@ -294,6 +294,7 @@ void Dialog::rebuildButtons()
         else if (this->buttons.size() == 2)
         {
             this->horizontalButtonsLayout = new BoxLayout(BoxLayoutOrientation::HORIZONTAL);
+            this->horizontalButtonsLayout->setParent(this);
             this->verticalButtonsLayout->addView(this->horizontalButtonsLayout);
 
             for (DialogButton* dialogButton : this->buttons)
@@ -311,6 +312,7 @@ void Dialog::rebuildButtons()
             this->verticalButtonsLayout->addView(button);
 
             this->horizontalButtonsLayout = new BoxLayout(BoxLayoutOrientation::HORIZONTAL);
+            this->horizontalButtonsLayout->setParent(this);
             this->verticalButtonsLayout->addView(this->horizontalButtonsLayout);
 
             for (size_t i = 1; i < this->buttons.size(); i++)


### PR DESCRIPTION
TabFrame: rightPane now manages responsibilty for displaying the sidebar item's view.
Dialog: set horizontalButtonsLayout's parent.

This is somewhat related to the Touch pr draft such that these modifications fix some problems with "touching" views.
This is separate from the Touch pr draft, since these changes do not depend on the Touch pr, and  could be merged without it.