### PR TITLE
Image class rewrite

### DIFF
--- a/library/include/borealis/applet_frame.hpp
+++ b/library/include/borealis/applet_frame.hpp
@@ -76,8 +76,9 @@ class AppletFrame : public View
     void setTitle(std::string title);
     void setFooterText(std::string footerText);
     void setSubtitle(std::string left, std::string right);
-    void setIcon(unsigned char* buffer, size_t bufferSize);
-    void setIcon(std::string imagePath);
+    void setIcon(const unsigned char* buffer, size_t bufferSize);
+    void setIconRGBA(const unsigned char* buffer, size_t width, size_t height);
+    void setIcon(const std::string &imagePath);
     void setIcon(View* view);
     virtual void setContentView(View* view);
     bool hasContentView();

--- a/library/include/borealis/button.hpp
+++ b/library/include/borealis/button.hpp
@@ -70,8 +70,9 @@ class Button : public View
     void setState(ButtonState state);
 
     Button* setLabel(std::string label);
-    Button* setImage(std::string path);
-    Button* setImage(unsigned char* buffer, size_t bufferSize);
+    Button* setImage(const std::string &path);
+    Button* setImage(const unsigned char* buffer, size_t bufferSize);
+    Button* setImageRGBA(const unsigned char* buffer, size_t width, size_t height);
 
     GenericEvent* getClickEvent();
 

--- a/library/include/borealis/image.hpp
+++ b/library/include/borealis/image.hpp
@@ -22,15 +22,6 @@
 #include <borealis/frame_context.hpp>
 #include <borealis/view.hpp>
 
-// fwd for std::swap
-namespace brls {
-  class Image;
-}
-// fwd for friend declaration in brls::Image
-namespace std {
-  void swap(brls::Image& a, brls::Image& b);
-}
-
 namespace brls
 {
 
@@ -46,23 +37,17 @@ enum class ImageScaleType
 // An image
 class Image : public View
 {
-  friend void std::swap(Image& a, Image&b);
   public:
     Image() = default;
-    Image(std::string imagePath);
-    Image(unsigned char* buffer, size_t bufferSize);
 
     ~Image();
-    Image(const Image& copy);
-    Image(Image&& move) noexcept;
-    Image& operator=(const Image& cp_assign);
-    Image& operator=(Image&& mv_assign);
 
     void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, Style* style, FrameContext* ctx) override;
     void layout(NVGcontext* vg, Style* style, FontStash* stash) override;
 
-    void setImage(unsigned char* buffer, size_t bufferSize);
-    void setImage(std::string imagePath);
+    void setImage(const std::string &path);
+    void setImage(const unsigned char* buffer, size_t bufferSize);
+    void setImageRGBA(const unsigned char* buffer, size_t width, size_t height);
 
     void setScaleType(ImageScaleType imageScaleType);
     void setOpacity(float opacity);
@@ -72,13 +57,7 @@ class Image : public View
         this->cornerRadius = radius;
     }
 
-    unsigned char* copyImgBuf() const;
-
   private:
-    std::string imagePath;
-    unsigned char* imageBuffer = nullptr;
-    size_t imageBufferSize     = 0;
-
     int texture = -1;
     NVGpaint imgPaint;
 
@@ -89,8 +68,6 @@ class Image : public View
     int imageX = 0, imageY = 0;
     int imageWidth = 0, imageHeight = 0;
     int origViewWidth = 0, origViewHeight = 0;
-
-    void reloadTexture();
 };
 
 } // namespace brls

--- a/library/include/borealis/list.hpp
+++ b/library/include/borealis/list.hpp
@@ -70,8 +70,9 @@ class ListItem : public View
     View* getDefaultFocus() override;
 
     void setThumbnail(Image* image);
-    void setThumbnail(std::string imagePath);
-    void setThumbnail(unsigned char* buffer, size_t bufferSize);
+    void setThumbnail(const std::string &imagePath);
+    void setThumbnail(const unsigned char* buffer, size_t bufferSize);
+    void setThumbnailRGBA(const unsigned char* buffer, size_t width, size_t height);
 
     bool hasDescription();
     void setDrawTopSeparator(bool draw);
@@ -150,6 +151,7 @@ class ToggleListItem : public ListItem
 
     virtual bool onClick() override;
 
+    void setToggleState(bool state);
     bool getToggleState();
 };
 

--- a/library/include/borealis/thumbnail_frame.hpp
+++ b/library/include/borealis/thumbnail_frame.hpp
@@ -44,8 +44,9 @@ class ThumbnailSidebar : public View
     void layout(NVGcontext* vg, Style* style, FontStash* stash) override;
     View* getDefaultFocus() override;
 
-    void setThumbnail(std::string imagePath);
-    void setThumbnail(unsigned char* buffer, size_t bufferSize);
+    void setThumbnail(const std::string &imagePath);
+    void setThumbnail(const unsigned char* buffer, size_t bufferSize);
+    void setThumbnailRGBA(const unsigned char* buffer, size_t width, size_t height);
 
     void setTitle(std::string title);
     void setSubtitle(std::string subTitle);

--- a/library/lib/applet_frame.cpp
+++ b/library/lib/applet_frame.cpp
@@ -256,11 +256,12 @@ void AppletFrame::setSubtitle(std::string left, std::string right)
     this->subTitleRight = right;
 }
 
-void AppletFrame::setIcon(unsigned char* buffer, size_t bufferSize)
+void AppletFrame::setIcon(const unsigned char* buffer, size_t bufferSize)
 {
     if (!this->icon)
     {
-        Image* icon = new Image(buffer, bufferSize);
+        Image* icon = new Image();
+        icon->setImage(buffer, bufferSize);
         icon->setScaleType(ImageScaleType::SCALE);
         icon->setParent(this);
 
@@ -274,11 +275,31 @@ void AppletFrame::setIcon(unsigned char* buffer, size_t bufferSize)
     this->icon->invalidate();
 }
 
-void AppletFrame::setIcon(std::string imagePath)
+void AppletFrame::setIconRGBA(const unsigned char* buffer, size_t width, size_t height)
 {
     if (!this->icon)
     {
-        Image* icon = new Image(imagePath);
+        Image* icon = new Image();
+        icon->setImageRGBA(buffer, width, height);
+        icon->setScaleType(ImageScaleType::SCALE);
+        icon->setParent(this);
+
+        this->icon = icon;
+    }
+    else if (Image* icon = dynamic_cast<Image*>(this->icon))
+    {
+        icon->setImageRGBA(buffer, width, height);
+    }
+
+    this->icon->invalidate();
+}
+
+void AppletFrame::setIcon(const std::string &imagePath)
+{
+    if (!this->icon)
+    {
+        Image* icon = new Image();
+        icon->setImage(imagePath);
         icon->setScaleType(ImageScaleType::SCALE);
         icon->setParent(this);
 

--- a/library/lib/button.cpp
+++ b/library/lib/button.cpp
@@ -98,16 +98,26 @@ Button* Button::setLabel(std::string label)
     return this;
 }
 
-Button* Button::setImage(std::string path)
+Button* Button::setImage(const std::string &path)
 {
-    this->image = new Image(path);
+    this->image = new Image();
+    this->image->setImage(path);
     this->image->setParent(this);
     return this;
 }
 
-Button* Button::setImage(unsigned char* buffer, size_t bufferSize)
+Button* Button::setImage(const unsigned char* buffer, size_t bufferSize)
 {
-    this->image = new Image(buffer, bufferSize);
+    this->image = new Image();
+    this->image->setImage(buffer, bufferSize);
+    this->image->setParent(this);
+    return this;
+}
+
+Button* Button::setImageRGBA(const unsigned char* buffer, size_t width, size_t height)
+{
+    this->image = new Image();
+    this->image->setImageRGBA(buffer, width, height);
     this->image->setParent(this);
     return this;
 }

--- a/library/lib/list.cpp
+++ b/library/lib/list.cpp
@@ -137,24 +137,36 @@ void ListItem::setThumbnail(Image* image)
     }
 }
 
-void ListItem::setThumbnail(std::string imagePath)
+void ListItem::setThumbnail(const std::string &imagePath)
 {
-    if (this->thumbnailView)
-        this->thumbnailView->setImage(imagePath);
-    else
-        this->thumbnailView = new Image(imagePath);
+    if (!this->thumbnailView)
+        this->thumbnailView = new Image();
+    
+    this->thumbnailView->setImage(imagePath);        
 
     this->thumbnailView->setParent(this);
     this->thumbnailView->setScaleType(ImageScaleType::FIT);
     this->invalidate();
 }
 
-void ListItem::setThumbnail(unsigned char* buffer, size_t bufferSize)
+void ListItem::setThumbnail(const unsigned char* buffer, size_t bufferSize)
 {
-    if (this->thumbnailView)
-        this->thumbnailView->setImage(buffer, bufferSize);
-    else
-        this->thumbnailView = new Image(buffer, bufferSize);
+    if (!this->thumbnailView)
+        this->thumbnailView = new Image();
+
+    this->thumbnailView->setImage(buffer, bufferSize);
+
+    this->thumbnailView->setParent(this);
+    this->thumbnailView->setScaleType(ImageScaleType::FIT);
+    this->invalidate();
+}
+
+void ListItem::setThumbnailRGBA(const unsigned char* buffer, size_t width, size_t height)
+{
+    if (!this->thumbnailView)
+        this->thumbnailView = new Image();
+
+    this->thumbnailView->setImageRGBA(buffer, width, height);
 
     this->thumbnailView->setParent(this);
     this->thumbnailView->setScaleType(ImageScaleType::FIT);
@@ -478,6 +490,12 @@ bool ToggleListItem::onClick()
 
     ListItem::onClick();
     return true;
+}
+
+void ToggleListItem::setToggleState(bool state)
+{
+    this->toggleState = state;
+    this->updateValue();
 }
 
 bool ToggleListItem::getToggleState()

--- a/library/lib/thumbnail_frame.cpp
+++ b/library/lib/thumbnail_frame.cpp
@@ -170,32 +170,37 @@ View* ThumbnailSidebar::getDefaultFocus()
     return this->button->getDefaultFocus();
 }
 
-void ThumbnailSidebar::setThumbnail(std::string imagePath)
+void ThumbnailSidebar::setThumbnail(const std::string &imagePath)
 {
-    if (this->image)
-    {
-        this->image->setImage(imagePath);
-    }
-    else
-    {
-        this->image = new Image(imagePath);
-        this->image->setParent(this);
-        this->invalidate();
-    }
+    if (!this->image)
+        this->image = new Image();
+
+    this->image->setImage(imagePath);
+    this->image->setScaleType(ImageScaleType::FIT);
+    this->image->setParent(this);
+    this->invalidate();
 }
 
-void ThumbnailSidebar::setThumbnail(unsigned char* buffer, size_t bufferSize)
+void ThumbnailSidebar::setThumbnail(const unsigned char* buffer, size_t bufferSize)
 {
-    if (this->image)
-    {
-        this->image->setImage(buffer, bufferSize);
-    }
-    else
-    {
-        this->image = new Image(buffer, bufferSize);
-        this->image->setParent(this);
-        this->invalidate();
-    }
+    if (!this->image)
+        this->image = new Image();
+
+    this->image->setImage(buffer, bufferSize);
+    this->image->setScaleType(ImageScaleType::FIT);
+    this->image->setParent(this);
+    this->invalidate();
+}
+
+void ThumbnailSidebar::setThumbnailRGBA(const unsigned char* buffer, size_t width, size_t height)
+{
+    if (!this->image)
+        this->image = new Image();
+
+    this->image->setImageRGBA(buffer, width, height);
+    this->image->setScaleType(ImageScaleType::FIT);
+    this->image->setParent(this);
+    this->invalidate();
 }
 
 void ThumbnailSidebar::setSubtitle(std::string subTitle)


### PR DESCRIPTION
- Image class no longer copies and stores the image data internally since that's completely unnecessary. 
- Added `setImageRGBA` function to Image and all Views that have an Image inside which allows usage of bmp files as image.
- Added setToggleState to ToggleListItem