### PR TITLE
Add description parameter to SelectListItem constructor

### DIFF
--- a/library/include/borealis/list.hpp
+++ b/library/include/borealis/list.hpp
@@ -120,7 +120,7 @@ typedef Event<int> ValueSelectedEvent;
 class SelectListItem : public ListItem
 {
   public:
-    SelectListItem(std::string label, std::vector<std::string> values, unsigned selectedValue = 0);
+    SelectListItem(std::string label, std::vector<std::string> values, unsigned selectedValue = 0, std::string description = "");
 
     void setSelectedValue(unsigned value);
 

--- a/library/lib/list.cpp
+++ b/library/lib/list.cpp
@@ -529,8 +529,8 @@ ListItemGroupSpacing::ListItemGroupSpacing(bool separator)
         this->setColor(theme->listItemSeparatorColor);
 }
 
-SelectListItem::SelectListItem(std::string label, std::vector<std::string> values, unsigned selectedValue)
-    : ListItem(label, "")
+SelectListItem::SelectListItem(std::string label, std::vector<std::string> values, unsigned selectedValue, std::string description)
+    : ListItem(label, description)
     , values(values)
     , selectedValue(selectedValue)
 {


### PR DESCRIPTION
All of the list item types have a `description` parameter in their constructors except for `SelectListItem`, so I added it to `SelectListItem` to ensure consistency and obviously make it easier to add a description to a `SelectListItem`.