### PR TITLE
Use sticks to navigate

### DIFF
--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -381,7 +381,7 @@ bool Application::mainLoop()
     const float* axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &count);
 
     //Make sure we got all our expected sticks before reading from them
-    if (count == 4)
+    if (count >= 4)
     {
         // Left Stick Y
         if (axes[1] < -.5)

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -375,7 +375,38 @@ bool Application::mainLoop()
     }
 
     // Trigger gamepad events
-    // TODO: Translate axis events to dpad events here
+
+    // Translate axis events to dpad events
+    int count;
+    const float* axes = glfwGetJoystickAxes(GLFW_JOYSTICK_1, &count);
+
+    //Make sure we got all our expected sticks before reading from them
+    if (count == 4)
+    {
+        // Left Stick X
+        if (axes[0] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+        else if (axes[0] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+
+        // Left Stick Y
+        if (axes[1] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
+        else if (axes[1] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
+
+        // Right Stick X
+        if (axes[2] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+        else if (axes[2] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+
+        // Right Stick Y
+        if (axes[3] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
+        else if (axes[3] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
+    }
 
     bool anyButtonPressed               = false;
     bool repeating                      = false;

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -383,33 +383,29 @@ bool Application::mainLoop()
     //Make sure we got all our expected sticks before reading from them
     if (count >= 4)
     {
+        // Left Stick X
+        if (axes[0] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+        else if (axes[0] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+
         // Left Stick Y
         if (axes[1] < -.5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
         else if (axes[1] > .5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
-        else
-        {
-            // Left Stick X
-            if (axes[0] < -.5)
-                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
-            else if (axes[0] > .5)
-                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
-        }
+
+        // Right Stick X
+        if (axes[2] < -.5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+        else if (axes[2] > .5)
+            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
 
         // Right Stick Y
         if (axes[3] < -.5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
         else if (axes[3] > .5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
-        else
-        {
-            // Right Stick X
-            if (axes[2] < -.5)
-                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
-            else if (axes[2] > .5)
-                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
-        }
     }
 
     bool anyButtonPressed               = false;

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -383,29 +383,33 @@ bool Application::mainLoop()
     //Make sure we got all our expected sticks before reading from them
     if (count == 4)
     {
-        // Left Stick X
-        if (axes[0] < -.5)
-            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
-        else if (axes[0] > .5)
-            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
-
         // Left Stick Y
         if (axes[1] < -.5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
         else if (axes[1] > .5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
-
-        // Right Stick X
-        if (axes[2] < -.5)
-            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
-        else if (axes[2] > .5)
-            Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+        else
+        {
+            // Left Stick X
+            if (axes[0] < -.5)
+                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+            else if (axes[0] > .5)
+                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+        }
 
         // Right Stick Y
         if (axes[3] < -.5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = GLFW_PRESS;
         else if (axes[3] > .5)
             Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = GLFW_PRESS;
+        else
+        {
+            // Right Stick X
+            if (axes[2] < -.5)
+                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = GLFW_PRESS;
+            else if (axes[2] > .5)
+                Application::gamepad.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = GLFW_PRESS;
+        }
     }
 
     bool anyButtonPressed               = false;


### PR DESCRIPTION
[Demo Vid](https://youtu.be/lTX_jIK_vpI)

Pretty straight-forward, quick and easy chunk of code that sets the d-pad nav values based on the stick states. Works perfect and feels great except for one thing.

The main problem is that [other, more wide-spread problem](https://github.com/natinusala/borealis/issues/27#issue-641814645), where if you push two directions at the same time, multiple things can accept the focus. This is a lot easier to do on the same frame with a diagonally pressed stick than pushing two distinct d-pad buttons at the same time. I can add a band-aid where it'll only accept right/left stick inputs when not pushing up/down, but like I said, that's just a fix for this one case.