### PR TITLE
Add draw clipping

### DIFF
--- a/library/include/borealis/view.hpp
+++ b/library/include/borealis/view.hpp
@@ -101,7 +101,7 @@ class View
 
     bool hidden = false;
 
-    bool clipping = true;
+    bool clipped = true;
 
     std::vector<Action> actions;
 
@@ -301,8 +301,8 @@ class View
 
     bool isHidden();
 
-    void setClipping(bool enable) { clipping = enable; }
-    bool isClipping() const { return clipping; };
+    void enableClipping(bool enable) { clipped = enable; }
+    bool isClippingEnabled(void) const { return clipped; };
 
     /**
       * Calls layout() on next frame

--- a/library/include/borealis/view.hpp
+++ b/library/include/borealis/view.hpp
@@ -101,6 +101,8 @@ class View
 
     bool hidden = false;
 
+    bool clipping = true;
+
     std::vector<Action> actions;
 
     /**
@@ -298,6 +300,9 @@ class View
     virtual void hide(std::function<void(void)> cb, bool animated = true, ViewAnimation animation = ViewAnimation::FADE);
 
     bool isHidden();
+
+    void setClipping(bool enable) { clipping = enable; }
+    bool isClipping() const { return clipping; };
 
     /**
       * Calls layout() on next frame

--- a/library/lib/list.cpp
+++ b/library/lib/list.cpp
@@ -37,10 +37,6 @@ ListContentView::ListContentView(List* list, size_t defaultFocus)
     : BoxLayout(BoxLayoutOrientation::VERTICAL, defaultFocus)
     , list(list)
 {
-    // We need to disable clipping so that this container will still be drawn.
-    // The children will only be drawn if in-bounds.
-    this->enableClipping(false);
-
     Style* style = Application::getStyle();
     this->setMargins(style->List.marginTopBottom, style->List.marginLeftRight, style->List.marginTopBottom, style->List.marginLeftRight);
     this->setSpacing(style->List.spacing);

--- a/library/lib/list.cpp
+++ b/library/lib/list.cpp
@@ -37,6 +37,10 @@ ListContentView::ListContentView(List* list, size_t defaultFocus)
     : BoxLayout(BoxLayoutOrientation::VERTICAL, defaultFocus)
     , list(list)
 {
+    // We need to disable clipping so that this container will still be drawn.
+    // The children will only be drawn if in-bounds.
+    this->setClipping(false);
+
     Style* style = Application::getStyle();
     this->setMargins(style->List.marginTopBottom, style->List.marginLeftRight, style->List.marginTopBottom, style->List.marginLeftRight);
     this->setSpacing(style->List.spacing);

--- a/library/lib/list.cpp
+++ b/library/lib/list.cpp
@@ -39,7 +39,7 @@ ListContentView::ListContentView(List* list, size_t defaultFocus)
 {
     // We need to disable clipping so that this container will still be drawn.
     // The children will only be drawn if in-bounds.
-    this->setClipping(false);
+    this->enableClipping(false);
 
     Style* style = Application::getStyle();
     this->setMargins(style->List.marginTopBottom, style->List.marginLeftRight, style->List.marginTopBottom, style->List.marginLeftRight);

--- a/library/lib/view.cpp
+++ b/library/lib/view.cpp
@@ -85,8 +85,8 @@ void View::frame(FrameContext* ctx)
     }
 
     if (this->alpha > 0.0f && this->collapseState != 0.0f && (!this->clipping ||
-        (this->x >= 0 && this->x <= static_cast<int>(Application::contentWidth) &&
-        this->y >= 0 && this->y <= static_cast<int>(Application::contentHeight))))
+        ((this->x + static_cast<int>(this->width)) >= 0 && this->x <= static_cast<int>(Application::contentWidth) &&
+        (this->y + static_cast<int>(this->height)) >= 0 && this->y <= static_cast<int>(Application::contentHeight))))
     {
         // Draw background
         this->drawBackground(ctx->vg, ctx, style);

--- a/library/lib/view.cpp
+++ b/library/lib/view.cpp
@@ -84,7 +84,9 @@ void View::frame(FrameContext* ctx)
         this->dirty = false;
     }
 
-    if (this->alpha > 0.0f && this->collapseState != 0.0f)
+    if (this->alpha > 0.0f && this->collapseState != 0.0f && (!this->clipping ||
+        (this->x >= 0 && this->x <= (int)Application::contentWidth &&
+        this->y >= 0 && this->y <= (int)Application::contentHeight)))
     {
         // Draw background
         this->drawBackground(ctx->vg, ctx, style);

--- a/library/lib/view.cpp
+++ b/library/lib/view.cpp
@@ -85,8 +85,8 @@ void View::frame(FrameContext* ctx)
     }
 
     if (this->alpha > 0.0f && this->collapseState != 0.0f && (!this->clipping ||
-        (this->x >= 0 && this->x <= (int)Application::contentWidth &&
-        this->y >= 0 && this->y <= (int)Application::contentHeight)))
+        (this->x >= 0 && this->x <= static_cast<int>(Application::contentWidth) &&
+        this->y >= 0 && this->y <= static_cast<int>(Application::contentHeight))))
     {
         // Draw background
         this->drawBackground(ctx->vg, ctx, style);

--- a/library/lib/view.cpp
+++ b/library/lib/view.cpp
@@ -84,7 +84,7 @@ void View::frame(FrameContext* ctx)
         this->dirty = false;
     }
 
-    if (this->alpha > 0.0f && this->collapseState != 0.0f && (!this->clipping ||
+    if (this->alpha > 0.0f && this->collapseState != 0.0f && (!this->clipped ||
         ((this->x + static_cast<int>(this->width)) >= 0 && this->x <= static_cast<int>(Application::contentWidth) &&
         (this->y + static_cast<int>(this->height)) >= 0 && this->y <= static_cast<int>(Application::contentHeight))))
     {


### PR DESCRIPTION
Only draw what's visible on screen. It can be toggled by the user for if they use a box container that needs to be drawn which has children which would be visible on screen. An example of this is the `ListContentView` class (I have updated the class).

I'll mention how the clipping works in the documentation later for the users.