### PR TITLE
Focus splitting fixes

### DIFF
--- a/library/include/borealis/application.hpp
+++ b/library/include/borealis/application.hpp
@@ -156,6 +156,8 @@ class Application
     static void cleanupNvgGlState();
 
   private:
+    inline static bool focusLocked = false;
+
     inline static GLFWwindow* window;
     inline static NVGcontext* vg;
 

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -442,6 +442,8 @@ bool Application::mainLoop()
         }
     }
 
+    focusLocked = false;
+
     return true;
 }
 
@@ -452,6 +454,14 @@ void Application::quit()
 
 void Application::navigate(FocusDirection direction)
 {
+    printf("Navigate: %i\n", direction);
+
+    if (focusLocked)
+    {
+        printf("Locked\n");
+        return;
+    }
+
     View* currentFocus = Application::currentFocus;
 
     // Do nothing if there is no current focus or if it doesn't have a parent
@@ -479,6 +489,7 @@ void Application::navigate(FocusDirection direction)
     }
 
     // Otherwise give it focus
+    focusLocked = true;
     Application::giveFocus(nextFocus);
 }
 

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -454,13 +454,8 @@ void Application::quit()
 
 void Application::navigate(FocusDirection direction)
 {
-    printf("Navigate: %i\n", direction);
-
     if (focusLocked)
-    {
-        printf("Locked\n");
         return;
-    }
 
     View* currentFocus = Application::currentFocus;
 

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -442,7 +442,7 @@ bool Application::mainLoop()
         }
     }
 
-    focusLocked = false;
+    Application::focusLocked = false;
 
     return true;
 }
@@ -454,7 +454,7 @@ void Application::quit()
 
 void Application::navigate(FocusDirection direction)
 {
-    if (focusLocked)
+    if (Application::focusLocked)
         return;
 
     View* currentFocus = Application::currentFocus;
@@ -484,7 +484,7 @@ void Application::navigate(FocusDirection direction)
     }
 
     // Otherwise give it focus
-    focusLocked = true;
+    Application::focusLocked = true;
     Application::giveFocus(nextFocus);
 }
 


### PR DESCRIPTION
Got it! Turned out to be surprisingly simple once I learned a bit how it worked more deeply.

This fixes https://github.com/natinusala/borealis/issues/27 by using a simple bool lock.

The lock is activated when/if the focus is successfully changed and deactivated at the end of the main loop each step. This way, only one view change can happen in one frame. I can't find any weirdness or problems with this solution in extensive testing.

This also gracefully fixes the problem with the sticks in https://github.com/natinusala/borealis/pull/52 and removes the need for its 'band-aid' solution.