### PR TITLE
Allow ListItem to use View types as thumbnails.

### DIFF
--- a/library/include/borealis/list.hpp
+++ b/library/include/borealis/list.hpp
@@ -50,7 +50,9 @@ class ListItem : public View
     bool drawTopSeparator = true;
 
     Label* descriptionView = nullptr;
-    Image* thumbnailView   = nullptr;
+    View* thumbnailView    = nullptr;
+
+    bool thumbnailIsImage = false;
 
     bool reduceDescriptionSpacing = false;
 
@@ -69,6 +71,7 @@ class ListItem : public View
     virtual bool onClick();
     View* getDefaultFocus() override;
 
+    void setThumbnail(View* view);
     void setThumbnail(Image* image);
     void setThumbnail(std::string imagePath);
     void setThumbnail(unsigned char* buffer, size_t bufferSize);


### PR DESCRIPTION
This change allows the use of View items as thumbnails while still preserving all previous functionality, as to not break anything that might depend on this.

There is some ugliness _in my opinion_ to how I did this, mainly the dynamic casts and some repetition, but I feel as this is the cleanest way to do things. Rather have a few lines of clear repetition than a convoluted interlinking mess.

Attached is a testing application [main.txt](https://github.com/natinusala/borealis/files/5112915/main.txt)

