### PR TITLE
Get borealis ready for C++20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__ \
 			-DBOREALIS_RESOURCES="\"$(BOREALIS_RESOURCES)\""
 
-CXXFLAGS	:= $(CFLAGS) -std=c++1z -O2
+CXXFLAGS	:= $(CFLAGS) -std=c++1z -O2 -Wno-volatile
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/library/lib/layer_view.cpp
+++ b/library/lib/layer_view.cpp
@@ -57,7 +57,7 @@ void LayerView::changeLayer(int index, bool focus)
 
         this->selectedIndex = index;
         this->layers[this->selectedIndex]->willAppear(true);
-        this->layers[this->selectedIndex]->show([=]() {
+        this->layers[this->selectedIndex]->show([this, focus]() {
             if (focus)
                 Application::giveFocus(this->layers[this->selectedIndex]->getDefaultFocus());
             Application::unblockInputs();


### PR DESCRIPTION
Some very minor tweaks to get borealis to build without warnings on C++20
- LayerView: `[=]` to implicitly capture `this` was deprecated in in C++20
- Makefile: One use of volatile, specifically reading and writing to a single volatile variable in one expression was deprecated, this happens in glm so it can't be fixed directly. `-Wno-volatile` disables this warning as it's generally not something that needs to be worried about within borealis.