### PR TITLE
Application: General i18n workaround for shared font loading

### DIFF
--- a/library/include/borealis/frame_context.hpp
+++ b/library/include/borealis/frame_context.hpp
@@ -31,6 +31,10 @@ class FontStash
 {
   public:
     int regular = 0;
+    int standard = 0;
+    int schinese  = 0;
+    int extSchinese  = 0;
+    int tchinese  = 0;
     int korean  = 0;
 
     int material      = 0;

--- a/library/include/borealis/i18n.hpp
+++ b/library/include/borealis/i18n.hpp
@@ -64,6 +64,14 @@ void loadTranslations();
  */
 std::string getCurrentLocale();
 
+#ifdef __SWITCH__
+/**
+ * Returns the current system locale id
+ * NOT the one that's currently used in the app!
+ */
+int swGetCurrentLocaleID();
+#endif
+
 inline namespace literals
 {
     /**

--- a/library/include/borealis/i18n.hpp
+++ b/library/include/borealis/i18n.hpp
@@ -64,13 +64,12 @@ void loadTranslations();
  */
 std::string getCurrentLocale();
 
-#ifdef __SWITCH__
 /**
  * Returns the current system locale id
+ * this id only make sense for libnx
  * NOT the one that's currently used in the app!
  */
-int swGetCurrentLocaleID();
-#endif
+int nxGetCurrentLocaleID();
 
 inline namespace literals
 {

--- a/library/lib/application.cpp
+++ b/library/lib/application.cpp
@@ -229,14 +229,14 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
 #ifdef __SWITCH__
     {
         PlFontData font;
-        int locale = i18n::swGetCurrentLocaleID();
+        SetLanguage localeID = (SetLanguage)i18n::nxGetCurrentLocaleID();
 
         // Standard font
         Result rc = plGetSharedFontByType(&font, PlSharedFontType_Standard);
         if (R_SUCCEEDED(rc))
         {
             Logger::info("Adding Switch shared standard font");
-            Application::fontStash.standard = Application::loadFontFromMemory("regular", font.address, font.size, false);
+            Application::fontStash.standard = Application::loadFontFromMemory("standard", font.address, font.size, false);
         }
 
         // Load other fonts on demand
@@ -245,10 +245,10 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
         if (at == AppletType_Application || at == AppletType_SystemApplication) // title takeover
         {
             isFullFallback = true;
-            Logger::warning("Non applet mode, font full fallback is enabled!");
+            Logger::info("Non applet mode, font full fallback is enabled!");
         }
         
-        if (locale == 6 || locale == 15 || isFullFallback)
+        if (localeID == SetLanguage_ZHCN || localeID == SetLanguage_ZHHANS || isFullFallback)
         {
             // S.Chinese font
             rc = plGetSharedFontByType(&font, PlSharedFontType_ChineseSimplified);
@@ -265,7 +265,7 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
                 Application::fontStash.extSchinese = Application::loadFontFromMemory("extSchinese", font.address, font.size, false);
             }
         }
-        if (locale == 11 || locale == 16 || isFullFallback)
+        if (localeID == SetLanguage_ZHTW || localeID == SetLanguage_ZHHANT || isFullFallback)
         {
             // T.Chinese font
             rc = plGetSharedFontByType(&font, PlSharedFontType_ChineseTraditional);
@@ -275,7 +275,7 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
                 Application::fontStash.tchinese = Application::loadFontFromMemory("tchinese", font.address, font.size, false);
             }
         }
-        if (locale == 7 || isFullFallback)
+        if (localeID == SetLanguage_KO || isFullFallback)
         {
             // Korean font
             rc = plGetSharedFontByType(&font, PlSharedFontType_KO);
@@ -287,33 +287,33 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
         }
 
         // Sequentially fallback to other fonts and decide regular font, also on demand
-        switch (locale)
+        switch (localeID)
             {
-                case 6 :
-                case 15 :
+                case SetLanguage_ZHCN :
+                case SetLanguage_ZHHANS :
                     if (isFullFallback)
                     {
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.korean);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.standard);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.tchinese);
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.extSchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.tchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.standard);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.korean);
                     }
                     else
                     {
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.standard);
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.extSchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.schinese, Application::fontStash.standard);
                     }
                     Logger::info("Using Switch shared S.Chinese font as regular");
                     Application::fontStash.regular = Application::fontStash.schinese;
                     break;
-                case 11 :
-                case 16 :
+                case SetLanguage_ZHTW :
+                case SetLanguage_ZHHANT :
                     if (isFullFallback)
                     {
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.korean);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.standard);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.extSchinese);
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.schinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.extSchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.standard);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.tchinese, Application::fontStash.korean);
                     }
                     else
                     {
@@ -322,13 +322,13 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
                     Logger::info("Using Switch shared T.Chinese font as regular");
                     Application::fontStash.regular = Application::fontStash.tchinese;
                     break;
-                case 7 :
+                case SetLanguage_KO :
                     if (isFullFallback)
                     {
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.standard);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.tchinese);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.extSchinese);
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.schinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.extSchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.korean, Application::fontStash.tchinese);
                     }
                     else
                     {
@@ -340,10 +340,10 @@ bool Application::init(std::string title, Style* style, LibraryViewsThemeVariant
                 default:
                     if (isFullFallback)
                     {
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.korean);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.tchinese);
-                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.extSchinese);
                         nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.schinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.extSchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.tchinese);
+                        nvgAddFallbackFontId(Application::vg, Application::fontStash.standard, Application::fontStash.korean);
                     }
                     Logger::info("Using Switch shared standard font as regular");
                     Application::fontStash.regular = Application::fontStash.standard;

--- a/library/lib/i18n.cpp
+++ b/library/lib/i18n.cpp
@@ -108,6 +108,34 @@ std::string getCurrentLocale()
     return DEFAULT_LOCALE;
 }
 
+#ifdef __SWITCH__
+int swGetCurrentLocaleID()
+{
+    u64 languageCode = 0;
+    SetLanguage setlanguage = SetLanguage_ENUS;
+
+    Result res = setGetSystemLanguage(&languageCode);
+
+    if (R_SUCCEEDED(res))
+    {
+        if (R_SUCCEEDED(res))
+        {
+            res = setMakeLanguage(languageCode, &setlanguage);
+            return (int)setlanguage;
+        }
+        else
+        {
+            brls::Logger::error("Unable to convert system language ID (error 0x{0:x}), using the default one: {1}", res, DEFAULT_LOCALE);
+        }
+    }
+    else
+    {
+        brls::Logger::error("Unable to get system language (error 0x{0:x}), using the default one: {1}", res, DEFAULT_LOCALE);
+    }
+    return 1; // SetLanguage_ENUS
+}
+#endif
+
 void loadTranslations()
 {
     loadLocale(DEFAULT_LOCALE, &defaultLocale);

--- a/library/lib/i18n.cpp
+++ b/library/lib/i18n.cpp
@@ -102,15 +102,15 @@ std::string getCurrentLocale()
     }
     else
     {
-        brls::Logger::error("Unable to get system language (error 0x{0:x}), using the default one: {1}", res, DEFAULT_LOCALE);
+        brls::Logger::error("Unable to get system language (error {0:#x}), using the default one: {1}", res, DEFAULT_LOCALE);
     }
 #endif
     return DEFAULT_LOCALE;
 }
 
-#ifdef __SWITCH__
-int swGetCurrentLocaleID()
+int nxGetCurrentLocaleID()
 {
+#ifdef __SWITCH__
     u64 languageCode = 0;
     SetLanguage setlanguage = SetLanguage_ENUS;
 
@@ -125,16 +125,16 @@ int swGetCurrentLocaleID()
         }
         else
         {
-            brls::Logger::error("Unable to convert system language ID (error 0x{0:x}), using the default one: {1}", res, DEFAULT_LOCALE);
+            brls::Logger::error("Unable to convert system language ID (error {0:#x}), using the default one: {1}", res, DEFAULT_LOCALE);
         }
     }
     else
     {
-        brls::Logger::error("Unable to get system language (error 0x{0:x}), using the default one: {1}", res, DEFAULT_LOCALE);
+        brls::Logger::error("Unable to get system language (error {0:#x}), using the default one: {1}", res, DEFAULT_LOCALE);
     }
+#endif
     return 1; // SetLanguage_ENUS
 }
-#endif
 
 void loadTranslations()
 {


### PR DESCRIPTION
This is similar to #49 but I made a more graceful implement (at least imo), and I didn't aware of #49 when I was writing this lol

For memory consuming concern, we do not load full fallback chain when we are not in title takeover mode.

Confirmed working for my WIP tiny tool.

**I'm not really a programmer** so let me know if cleanup/optimization is needed.

---
Still I have a question, I can't really figure out how `nvgAddFallbackFontId` push the fallback order so I may have reversed my intend.

For example:
```
nvgAddFallbackFontId(Application::vg, Application::fontStash.regular, Application::fontStash.korean);
nvgAddFallbackFontId(Application::vg, Application::fontStash.regular, Application::fontStash.sharedSymbols);
```
does make the order `regular`->`korean`->`symbol` (appending) or `regular`->`symbol`->`korean` (prepending)? 