### PR TITLE
Fixed scrollviews scrolling when not in focus

### DIFF
--- a/library/include/borealis/sidebar.hpp
+++ b/library/include/borealis/sidebar.hpp
@@ -47,6 +47,8 @@ class SidebarItem : public View
     Sidebar* sidebar     = nullptr;
     View* associatedView = nullptr;
 
+    ViewType viewType = ViewType::SIDEBARITEM;
+
   public:
     SidebarItem(std::string label, Sidebar* sidebar);
 
@@ -66,6 +68,7 @@ class SidebarItem : public View
 
     void setAssociatedView(View* view);
     View* getAssociatedView();
+    ViewType getViewType() override;
 
     ~SidebarItem();
 };

--- a/library/include/borealis/view.hpp
+++ b/library/include/borealis/view.hpp
@@ -61,6 +61,12 @@ enum class ViewBackground
     BACKDROP
 };
 
+enum class ViewType
+{
+  VIEW,
+  SIDEBARITEM,
+};
+
 extern NVGcolor transparent;
 
 class View;
@@ -102,6 +108,8 @@ class View
     bool hidden = false;
 
     std::vector<Action> actions;
+
+    ViewType viewType = ViewType::VIEW;
 
     /**
      * Parent user data, typically the index of the view
@@ -209,6 +217,11 @@ class View
     const std::vector<Action>& getActions()
     {
         return this->actions;
+    }
+
+    virtual ViewType getViewType()
+    {
+        return this->viewType;
     }
 
     /**

--- a/library/lib/scroll_view.cpp
+++ b/library/lib/scroll_view.cpp
@@ -141,7 +141,11 @@ bool ScrollView::updateScrolling(bool animated)
     if (contentHeight == 0)
         return false;
 
-    View* focusedView                  = Application::getCurrentFocus();
+    // Don't scroll if the focus not on the current View
+    View* focusedView = Application::getCurrentFocus();
+    if (focusedView->getViewType() != this->getViewType())
+        return false;
+
     int currentSelectionMiddleOnScreen = focusedView->getY() + focusedView->getHeight() / 2;
     float newScroll                    = -(this->scrollY * contentHeight) - ((float)currentSelectionMiddleOnScreen - (float)this->middleY);
 

--- a/library/lib/sidebar.cpp
+++ b/library/lib/sidebar.cpp
@@ -169,6 +169,11 @@ View* SidebarItem::getAssociatedView()
     return this->associatedView;
 }
 
+ViewType SidebarItem::getViewType()
+{
+    return this->viewType;
+}
+
 SidebarItem::~SidebarItem()
 {
     if (this->associatedView)


### PR DESCRIPTION
When using a tabFrame, the scrollview of the right panel would scroll with a value calculated with the Y of the focused tab, this makes sure scrollviews only scroll if they're in focus.

I only added these viewtypes because they're the only ones I needed, but this can be extended
```C++
enum class ViewType
{
  VIEW,
  SIDEBARITEM,
};
```