### PR TITLE
Added option to enable or disable global actions

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -53,6 +53,9 @@ int main(int argc, char* argv[])
 
     brls::Application::createWindow("demo/title"_i18n);
 
+    // Have the application register an action on every activity that will quit when you press BUTTON_START
+    brls::Application::setGlobalQuit(true);
+
     // Register custom views (including tabs, which are views)
     brls::Application::registerXMLView("CaptionedImage", CaptionedImage::create);
     brls::Application::registerXMLView("RecyclingListTab", RecyclingListTab::create);

--- a/library/include/borealis/core/actions.hpp
+++ b/library/include/borealis/core/actions.hpp
@@ -28,11 +28,15 @@ class View;
 
 typedef std::function<bool(View*)> ActionListener;
 
+typedef int ActionIdentifier;
+
+#define ACTION_NONE -1
+
 struct Action
 {
     enum ControllerButton button;
 
-    int identifier;
+    ActionIdentifier identifier;
     std::string hintText;
     bool available;
     bool hidden;

--- a/library/include/borealis/core/actions.hpp
+++ b/library/include/borealis/core/actions.hpp
@@ -32,6 +32,7 @@ struct Action
 {
     enum ControllerButton button;
 
+    int identifier;
     std::string hintText;
     bool available;
     bool hidden;

--- a/library/include/borealis/core/activity.hpp
+++ b/library/include/borealis/core/activity.hpp
@@ -116,9 +116,28 @@ class Activity
 
     bool isHidden();
 
-    void registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
+    /**
+     * Registers an action with the given parameters on the content view. The listener will be fired
+     * when the user presses the key.
+     *
+     * The listener should return true if the action was consumed, false otherwise.
+     * The sound will only be played if the listener returned true.
+     *
+     * A hidden action will not show up in the bottom-right hints.
+     *
+     * Must be called after the content view is set.
+     *
+     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * action was not registered.
+     */
+    int registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
-    void unregisterAction(std::string hintText, enum ControllerButton button, bool hidden = false, enum Sound sound = SOUND_NONE);
+    /**
+     * Unregisters an action with the given identifier on the content view.
+     *
+     * Must be called after the content view is set.
+     */
+    void unregisterAction(int identifier);
 
     void onWindowSizeChanged();
 

--- a/library/include/borealis/core/activity.hpp
+++ b/library/include/borealis/core/activity.hpp
@@ -118,6 +118,8 @@ class Activity
 
     void registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
+    void unregisterAction(std::string hintText, enum ControllerButton button, bool hidden = false, enum Sound sound = SOUND_NONE);
+
     void onWindowSizeChanged();
 
     View* getDefaultFocus();

--- a/library/include/borealis/core/activity.hpp
+++ b/library/include/borealis/core/activity.hpp
@@ -127,27 +127,27 @@ class Activity
      *
      * Must be called after the content view is set.
      *
-     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * Returns the identifier for the action, so it can be unregistered later on. Returns ACTION_NONE if the
      * action was not registered.
      */
-    int registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
+    ActionIdentifier registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
     /**
      * Unregisters an action with the given identifier on the content view.
      *
      * Must be called after the content view is set.
      */
-    void unregisterAction(int identifier);
+    void unregisterAction(ActionIdentifier identifier);
 
     /**
      * Registers an action to exit the application with the default button BUTTON_START.
      *
      * Must be called after the content view is set.
      *
-     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * Returns the identifier for the action, so it can be unregistered later on. Returns ACTION_NONE if the
      * action was not registered.
      */
-    int registerExitAction(enum ControllerButton button = brls::BUTTON_START);
+    ActionIdentifier registerExitAction(enum ControllerButton button = brls::BUTTON_START);
 
     void onWindowSizeChanged();
 

--- a/library/include/borealis/core/activity.hpp
+++ b/library/include/borealis/core/activity.hpp
@@ -139,6 +139,16 @@ class Activity
      */
     void unregisterAction(int identifier);
 
+    /**
+     * Registers an action to exit the application with the default button BUTTON_START.
+     *
+     * Must be called after the content view is set.
+     *
+     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * action was not registered.
+     */
+    int registerExitAction(enum ControllerButton button = brls::BUTTON_START);
+
     void onWindowSizeChanged();
 
     View* getDefaultFocus();

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -156,7 +156,14 @@ class Application
 
     inline static float windowScale;
 
+    /**
+     * Sets whether BUTTON_START will globally be used to close the application.
+     */
     static void setGlobalQuit(bool enabled);
+
+    /**
+     * Sets whether BUTTON_BACK will globally be used to toggle an FPS display.
+     */
     static void setGlobalFPSToggle(bool enabled);
 
     static GenericEvent* getGlobalFocusChangeEvent();

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -156,6 +156,9 @@ class Application
 
     inline static float windowScale;
 
+    static void setGlobalQuit(bool enabled);
+    static void setGlobalFPSToggle(bool enabled);
+
     static GenericEvent* getGlobalFocusChangeEvent();
     static VoidEvent* getGlobalHintsUpdateEvent();
 
@@ -202,6 +205,9 @@ class Application
     inline static unsigned blockInputsTokens = 0; // any value > 0 means inputs are blocked
 
     inline static std::string commonFooter = "";
+
+    inline static bool globalQuitEnabled = true;
+    inline static bool globalFPSToggleEnabled = true;
 
     inline static View* repetitionOldFocus = nullptr;
 

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -28,10 +28,8 @@
 #include <borealis/core/platform.hpp>
 #include <borealis/core/style.hpp>
 #include <borealis/core/theme.hpp>
-
 #include <borealis/core/view.hpp>
 #include <borealis/views/label.hpp>
-
 #include <unordered_map>
 #include <vector>
 
@@ -213,10 +211,10 @@ class Application
 
     inline static std::string commonFooter = "";
 
-    inline static bool globalQuitEnabled = false;
-    inline static int gloablQuitIdentifier = -1;
-    inline static bool globalFPSToggleEnabled = false;
-    inline static int gloablFPSToggleIdentifier = -1;
+    inline static bool globalQuitEnabled                     = false;
+    inline static ActionIdentifier gloablQuitIdentifier      = ACTION_NONE;
+    inline static bool globalFPSToggleEnabled                = false;
+    inline static ActionIdentifier gloablFPSToggleIdentifier = ACTION_NONE;
 
     inline static View* repetitionOldFocus = nullptr;
 

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -239,6 +239,8 @@ class Application
     static bool handleAction(char button);
 
     static void registerBuiltInXMLViews();
+
+    static ActionIdentifier registerFPSToggleAction(Activity* activity);
 };
 
 } // namespace brls

--- a/library/include/borealis/core/application.hpp
+++ b/library/include/borealis/core/application.hpp
@@ -206,8 +206,10 @@ class Application
 
     inline static std::string commonFooter = "";
 
-    inline static bool globalQuitEnabled = true;
-    inline static bool globalFPSToggleEnabled = true;
+    inline static bool globalQuitEnabled = false;
+    inline static int gloablQuitIdentifier = -1;
+    inline static bool globalFPSToggleEnabled = false;
+    inline static int gloablFPSToggleIdentifier = -1;
 
     inline static View* repetitionOldFocus = nullptr;
 

--- a/library/include/borealis/core/view.hpp
+++ b/library/include/borealis/core/view.hpp
@@ -988,6 +988,11 @@ class View
     void registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
     /**
+     * Unregisters an action for the given button.
+     */
+    void unregisterAction(std::string hintText, enum ControllerButton button, bool hidden = false, enum Sound sound = SOUND_NONE);
+
+    /**
      * Shortcut to register a generic "A OK" click action.
      */
     void registerClickAction(ActionListener actionListener);

--- a/library/include/borealis/core/view.hpp
+++ b/library/include/borealis/core/view.hpp
@@ -985,15 +985,15 @@ class View
      *
      * A hidden action will not show up in the bottom-right hints.
      *
-     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * Returns the identifier for the action, so it can be unregistered later on. Returns ACTION_NONE if the
      * action was not registered.
      */
-    int registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
+    ActionIdentifier registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
     /**
      * Unregisters an action with the given identifier.
      */
-    void unregisterAction(int identifier);
+    void unregisterAction(ActionIdentifier identifier);
 
     /**
      * Shortcut to register a generic "A OK" click action.

--- a/library/include/borealis/core/view.hpp
+++ b/library/include/borealis/core/view.hpp
@@ -984,13 +984,16 @@ class View
      * The sound will only be played if the listener returned true.
      *
      * A hidden action will not show up in the bottom-right hints.
+     *
+     * Returns the identifier for the action, so it can be unregistered later on. Returns -1 if the
+     * action was not registered.
      */
-    void registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
+    int registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden = false, enum Sound sound = SOUND_NONE);
 
     /**
-     * Unregisters an action for the given button.
+     * Unregisters an action with the given identifier.
      */
-    void unregisterAction(std::string hintText, enum ControllerButton button, bool hidden = false, enum Sound sound = SOUND_NONE);
+    void unregisterAction(int identifier);
 
     /**
      * Shortcut to register a generic "A OK" click action.

--- a/library/lib/core/activity.cpp
+++ b/library/lib/core/activity.cpp
@@ -115,26 +115,26 @@ bool Activity::isHidden()
     return this->contentView->isHidden();
 }
 
-int Activity::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
+ActionIdentifier Activity::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
 {
     if (this->contentView)
         return this->contentView->registerAction(hintText, button, actionListener, hidden, sound);
 
-    return -1;
+    return ACTION_NONE;
 }
 
-void Activity::unregisterAction(int identifier)
+void Activity::unregisterAction(ActionIdentifier identifier)
 {
     if (this->contentView)
         this->contentView->unregisterAction(identifier);
 }
 
-int Activity::registerExitAction(enum ControllerButton button)
+ActionIdentifier Activity::registerExitAction(enum ControllerButton button)
 {
     if (this->contentView)
         return this->contentView->registerAction("brls/hints/exit"_i18n, button, [](View* view) { Application::quit(); return true; });
 
-    return -1;
+    return ACTION_NONE;
 }
 
 View* Activity::getDefaultFocus()

--- a/library/lib/core/activity.cpp
+++ b/library/lib/core/activity.cpp
@@ -118,6 +118,12 @@ void Activity::registerAction(std::string hintText, enum ControllerButton button
         this->contentView->registerAction(hintText, button, actionListener, hidden, sound);
 }
 
+void Activity::unregisterAction(std::string hintText, enum ControllerButton button, bool hidden, enum Sound sound)
+{
+    if (this->contentView)
+        this->contentView->unregisterAction(hintText, button, hidden, sound);
+}
+
 View* Activity::getDefaultFocus()
 {
     if (!this->contentView)

--- a/library/lib/core/activity.cpp
+++ b/library/lib/core/activity.cpp
@@ -112,16 +112,18 @@ bool Activity::isHidden()
     return this->contentView->isHidden();
 }
 
-void Activity::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
+int Activity::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
 {
     if (this->contentView)
-        this->contentView->registerAction(hintText, button, actionListener, hidden, sound);
+        return this->contentView->registerAction(hintText, button, actionListener, hidden, sound);
+
+    return -1;
 }
 
-void Activity::unregisterAction(std::string hintText, enum ControllerButton button, bool hidden, enum Sound sound)
+void Activity::unregisterAction(int identifier)
 {
     if (this->contentView)
-        this->contentView->unregisterAction(hintText, button, hidden, sound);
+        this->contentView->unregisterAction(identifier);
 }
 
 View* Activity::getDefaultFocus()

--- a/library/lib/core/activity.cpp
+++ b/library/lib/core/activity.cpp
@@ -16,6 +16,9 @@
 
 #include <borealis/core/activity.hpp>
 #include <borealis/core/application.hpp>
+#include <borealis/core/i18n.hpp>
+
+using namespace brls::literals;
 
 namespace brls
 {
@@ -124,6 +127,14 @@ void Activity::unregisterAction(int identifier)
 {
     if (this->contentView)
         this->contentView->unregisterAction(identifier);
+}
+
+int Activity::registerExitAction(enum ControllerButton button)
+{
+    if (this->contentView)
+        return this->contentView->registerAction("brls/hints/exit"_i18n, button, [](View* view) { Application::quit(); return true; });
+
+    return -1;
 }
 
 View* Activity::getDefaultFocus()

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -51,8 +51,6 @@ constexpr uint32_t ORIGINAL_WINDOW_HEIGHT = 720;
 #define BUTTON_REPEAT_DELAY 15
 #define BUTTON_REPEAT_CADENCY 5
 
-using namespace brls::literals;
-
 namespace brls
 {
 
@@ -439,8 +437,7 @@ void Application::setGlobalQuit(bool enabled) {
     Application::globalQuitEnabled = enabled;
     for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
         if (enabled)
-            Application::gloablQuitIdentifier = (*it)->registerAction(
-                "brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+            Application::gloablQuitIdentifier = (*it)->registerExitAction();
         else
             (*it)->unregisterAction(Application::gloablQuitIdentifier);
     }
@@ -562,8 +559,7 @@ void Application::pushActivity(Activity* activity, TransitionAnimation animation
     bool wait    = animation == TransitionAnimation::FADE; // wait for the old activity animation to be done before showing the new one?
 
     if (Application::globalQuitEnabled)
-        Application::gloablQuitIdentifier = activity->registerAction(
-            "brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+        Application::gloablQuitIdentifier = activity->registerExitAction();
 
     if (Application::globalFPSToggleEnabled)
         Application::gloablFPSToggleIdentifier = activity->registerAction(

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -439,9 +439,10 @@ void Application::setGlobalQuit(bool enabled) {
     Application::globalQuitEnabled = enabled;
     for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
         if (enabled)
-            (*it)->registerAction("brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+            Application::gloablQuitIdentifier = (*it)->registerAction(
+                "brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
         else
-            (*it)->unregisterAction("brls/hints/exit"_i18n, BUTTON_START);
+            (*it)->unregisterAction(Application::gloablQuitIdentifier);
     }
 }
 
@@ -449,10 +450,10 @@ void Application::setGlobalFPSToggle(bool enabled) {
     Application::globalFPSToggleEnabled = enabled;
     for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
         if (enabled)
-            (*it)->registerAction(
+            Application::gloablFPSToggleIdentifier = (*it)->registerAction(
                 "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
         else
-            (*it)->unregisterAction("FPS", BUTTON_BACK, true);
+            (*it)->unregisterAction(Application::gloablFPSToggleIdentifier);
     }
 }
 
@@ -561,10 +562,11 @@ void Application::pushActivity(Activity* activity, TransitionAnimation animation
     bool wait    = animation == TransitionAnimation::FADE; // wait for the old activity animation to be done before showing the new one?
 
     if (Application::globalQuitEnabled)
-        activity->registerAction("brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+        Application::gloablQuitIdentifier = activity->registerAction(
+            "brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
 
     if (Application::globalFPSToggleEnabled)
-        activity->registerAction(
+        Application::gloablFPSToggleIdentifier = activity->registerAction(
             "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
 
     // Fade out animation

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -435,6 +435,27 @@ void Application::toggleFramerateDisplay()
     // To be implemented (call setDisplayFramerate)
 }
 
+void Application::setGlobalQuit(bool enabled) {
+    Application::globalQuitEnabled = enabled;
+    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
+        if (enabled)
+            (*it)->registerAction("brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+        else
+            (*it)->unregisterAction("brls/hints/exit"_i18n, BUTTON_START);
+    }
+}
+
+void Application::setGlobalFPSToggle(bool enabled) {
+    Application::globalFPSToggleEnabled = enabled;
+    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
+        if (enabled)
+            (*it)->registerAction(
+                "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
+        else
+            (*it)->unregisterAction("FPS", BUTTON_BACK, true);
+    }
+}
+
 void Application::notify(std::string text)
 {
     // To be implemented
@@ -539,9 +560,12 @@ void Application::pushActivity(Activity* activity, TransitionAnimation animation
     bool fadeOut = last && !last->isTranslucent() && !activity->isTranslucent(); // play the fade out animation?
     bool wait    = animation == TransitionAnimation::FADE; // wait for the old activity animation to be done before showing the new one?
 
-    activity->registerAction("brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
-    activity->registerAction(
-        "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
+    if (Application::globalQuitEnabled)
+        activity->registerAction("brls/hints/exit"_i18n, BUTTON_START, [](View* view) { Application::quit(); return true; });
+
+    if (Application::globalFPSToggleEnabled)
+        activity->registerAction(
+            "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
 
     // Fade out animation
     if (fadeOut)

--- a/library/lib/core/application.cpp
+++ b/library/lib/core/application.cpp
@@ -433,9 +433,17 @@ void Application::toggleFramerateDisplay()
     // To be implemented (call setDisplayFramerate)
 }
 
-void Application::setGlobalQuit(bool enabled) {
+ActionIdentifier Application::registerFPSToggleAction(Activity* activity)
+{
+    return activity->registerAction(
+        "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
+}
+
+void Application::setGlobalQuit(bool enabled)
+{
     Application::globalQuitEnabled = enabled;
-    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
+    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it)
+    {
         if (enabled)
             Application::gloablQuitIdentifier = (*it)->registerExitAction();
         else
@@ -443,12 +451,13 @@ void Application::setGlobalQuit(bool enabled) {
     }
 }
 
-void Application::setGlobalFPSToggle(bool enabled) {
+void Application::setGlobalFPSToggle(bool enabled)
+{
     Application::globalFPSToggleEnabled = enabled;
-    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it) {
+    for (auto it = Application::activitiesStack.begin(); it != Application::activitiesStack.end(); ++it)
+    {
         if (enabled)
-            Application::gloablFPSToggleIdentifier = (*it)->registerAction(
-                "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
+            Application::gloablFPSToggleIdentifier = Application::registerFPSToggleAction(*it);
         else
             (*it)->unregisterAction(Application::gloablFPSToggleIdentifier);
     }
@@ -562,8 +571,7 @@ void Application::pushActivity(Activity* activity, TransitionAnimation animation
         Application::gloablQuitIdentifier = activity->registerExitAction();
 
     if (Application::globalFPSToggleEnabled)
-        Application::gloablFPSToggleIdentifier = activity->registerAction(
-            "FPS", BUTTON_BACK, [](View* view) { Application::toggleFramerateDisplay(); return true; }, true);
+        Application::gloablFPSToggleIdentifier = Application::registerFPSToggleAction(activity);
 
     // Fade out animation
     if (fadeOut)

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -619,6 +619,16 @@ void View::registerAction(std::string hintText, enum ControllerButton button, Ac
         this->actions.push_back({ button, hintText, true, hidden, sound, actionListener });
 }
 
+void View::unregisterAction(std::string hintText, enum ControllerButton button, bool hidden, enum Sound sound)
+{
+    auto is_matched_action = [hintText, button, hidden, sound](Action action)
+    {
+        return action.hintText == hintText && action.button == button && action.hidden == hidden && action.sound == sound;
+    };
+    if (auto it = std::find_if(this->actions.begin(), this->actions.end(), is_matched_action); it != this->actions.end())
+        this->actions.erase(it);
+}
+
 void View::registerClickAction(ActionListener actionListener)
 {
     this->registerAction("brls/hints/ok"_i18n, BUTTON_A, actionListener, false, SOUND_CLICK);

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -611,9 +611,9 @@ void View::drawBackground(NVGcontext* vg, FrameContext* ctx, Style style)
     }
 }
 
-int View::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
+ActionIdentifier View::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
 {
-    int nextIdentifier = (this->actions.size() == 0) ? 1 : this->actions.back().identifier + 1;
+    ActionIdentifier nextIdentifier = (this->actions.size() == 0) ? 1 : this->actions.back().identifier + 1;
 
     if (auto it = std::find(this->actions.begin(), this->actions.end(), button); it != this->actions.end())
         *it = { button, nextIdentifier, hintText, true, hidden, sound, actionListener };
@@ -623,10 +623,9 @@ int View::registerAction(std::string hintText, enum ControllerButton button, Act
     return nextIdentifier;
 }
 
-void View::unregisterAction(int identifier)
+void View::unregisterAction(ActionIdentifier identifier)
 {
-    auto is_matched_action = [identifier](Action action)
-    {
+    auto is_matched_action = [identifier](Action action) {
         return action.identifier == identifier;
     };
     if (auto it = std::find_if(this->actions.begin(), this->actions.end(), is_matched_action); it != this->actions.end())

--- a/library/lib/core/view.cpp
+++ b/library/lib/core/view.cpp
@@ -611,19 +611,23 @@ void View::drawBackground(NVGcontext* vg, FrameContext* ctx, Style style)
     }
 }
 
-void View::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
+int View::registerAction(std::string hintText, enum ControllerButton button, ActionListener actionListener, bool hidden, enum Sound sound)
 {
+    int nextIdentifier = (this->actions.size() == 0) ? 1 : this->actions.back().identifier + 1;
+
     if (auto it = std::find(this->actions.begin(), this->actions.end(), button); it != this->actions.end())
-        *it = { button, hintText, true, hidden, sound, actionListener };
+        *it = { button, nextIdentifier, hintText, true, hidden, sound, actionListener };
     else
-        this->actions.push_back({ button, hintText, true, hidden, sound, actionListener });
+        this->actions.push_back({ button, nextIdentifier, hintText, true, hidden, sound, actionListener });
+
+    return nextIdentifier;
 }
 
-void View::unregisterAction(std::string hintText, enum ControllerButton button, bool hidden, enum Sound sound)
+void View::unregisterAction(int identifier)
 {
-    auto is_matched_action = [hintText, button, hidden, sound](Action action)
+    auto is_matched_action = [identifier](Action action)
     {
-        return action.hintText == hintText && action.button == button && action.hidden == hidden && action.sound == sound;
+        return action.identifier == identifier;
     };
     if (auto it = std::find_if(this->actions.begin(), this->actions.end(), is_matched_action); it != this->actions.end())
         this->actions.erase(it);


### PR DESCRIPTION
Another thing we talked about on Discord. When running as qlaunch you don't want the user from being able to ever exit out of it. The other use case was for updaters (Or even when just an app is updating itself) where if the user were to exit it would leave their SD card or the app itself in a possible broken state. I also included an option to enable and disable the FPS toggle as I could see that being useful for debugging, but probably don't want to keep that in for release builds.