### PR TITLE
Make the devide by 0 button actually devide by 0

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -103,8 +103,11 @@ int main(int argc, char* argv[])
             "main/jank/ios"_i18n,
         });
 
-    brls::ListItem* crashItem = new brls::ListItem("main/divide/title"_i18n, "main/divide/description"_i18n);
-    crashItem->getClickEvent()->subscribe([](brls::View* view) { brls::Application::crash("main/divide/crash"_i18n); });
+    brls::ListItem* devideItem = new brls::ListItem("main/divide/title"_i18n, "main/divide/description"_i18n);
+    devideItem->getClickEvent()->subscribe([](brls::View* view) {
+        std::string notification = "It is possible! 10/0 = " + std::to_string(10/0);
+        brls::Application::notify(notification);
+    });
 
     brls::ListItem* popupItem = new brls::ListItem("popup/open"_i18n);
     popupItem->getClickEvent()->subscribe([](brls::View* view) {


### PR DESCRIPTION
Currently when you press the divide by 0 there is no actual division taking place: there is just a call to an artificial crash. I fixed it so there is an actual division taking place and the answer is displayed in a notification just in case it succeeds. 