### PR TITLE
legacy: ScrollView: fix content view start scroll offset when the sidebar item is initially focused.

### DIFF
--- a/library/lib/scroll_view.cpp
+++ b/library/lib/scroll_view.cpp
@@ -141,8 +141,16 @@ bool ScrollView::updateScrolling(bool animated)
     if (contentHeight == 0)
         return false;
 
-    View* focusedView                  = Application::getCurrentFocus();
-    int currentSelectionMiddleOnScreen = focusedView->getY() + focusedView->getHeight() / 2;
+    // Ensure we're dealing with a focused view with a parent
+    View* focusedView = Application::getCurrentFocus();
+    if (!focusedView || !focusedView->hasParent())
+        return false;
+
+    // We're only going to use focusedView's properties if its parent matches our contentView
+    bool useFocusedView = (focusedView->getParent() == this->contentView);
+
+    // Calculate scroll value
+    int currentSelectionMiddleOnScreen = (useFocusedView ? (focusedView->getY() + focusedView->getHeight() / 2) : this->contentView->getY());
     float newScroll                    = -(this->scrollY * contentHeight) - ((float)currentSelectionMiddleOnScreen - (float)this->middleY);
 
     // Bottom boundary


### PR DESCRIPTION
Previous behaviour would mistakenly use boundary values from the focused `SidebarItem` *instead* of a child from the `ScrollView`'s content view, leading to content views not being initially rendered at scroll offset `0.0f`.

This issue becomes evident when using long content views for `SidebarItem` elements beyond the first one.

The problem is fixed by checking if the focused view's parent matches the `ScrollView`'s content view. If the focused item isn't a child of the content view, `currentSelectionMiddleOnScreen` is set to the content view's Y coordinate.