### PR TITLE
Support newer libnx version

### DIFF
--- a/library/lib/extern/nanovg-deko3d/include/nanovg/dk_renderer.hpp
+++ b/library/lib/extern/nanovg-deko3d/include/nanovg/dk_renderer.hpp
@@ -3,6 +3,7 @@
 #include <deko3d.hpp>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "framework/CDescriptorSet.h"

--- a/library/lib/platforms/switch/swkbd.cpp
+++ b/library/lib/platforms/switch/swkbd.cpp
@@ -39,7 +39,7 @@ static SwkbdConfig createSwkbdBaseConfig(std::string headerText, std::string sub
     swkbdConfigSetSubText(&config, subText.c_str());
     swkbdConfigSetStringLenMax(&config, maxStringLength);
     swkbdConfigSetInitialText(&config, initialText.c_str());
-    swkbdConfigSetStringLenMaxExt(&config, 1);
+    swkbdConfigSetStringLenMin(&config, 1);
     swkbdConfigSetBlurBackground(&config, true);
 
     return config;


### PR DESCRIPTION
It appears that `swkbdConfigSetStringLenMaxExt` was replaced with `swkbdConfigSetStringLenMin` on the libnx repo... I was having trouble building the demo because of this. I also noticed std::optional was used but not included in the dx_renderer.hpp file? Not sure if thats a change that should be kept, but that was also causing problems for me.